### PR TITLE
Admin Controller 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -32,6 +32,9 @@ dependencies {
     runtimeOnly 'com.h2database:h2'
     runtimeOnly 'com.mysql:mysql-connector-j'
 
+    // hal Explorer
+    implementation 'org.springframework.data:spring-data-rest-hal-explorer'
+
     // thymeleaf
     implementation 'org.springframework.boot:spring-boot-starter-thymeleaf'
 

--- a/src/main/java/org/dry/controller/AdminRestController.java
+++ b/src/main/java/org/dry/controller/AdminRestController.java
@@ -1,0 +1,35 @@
+package org.dry.controller;
+
+import org.dry.entity.Admin;
+import org.dry.service.AdminService;
+import org.dry.vo.IdAndPassword;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.rest.core.annotation.RepositoryRestResource;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RequestMapping("/admin")
+@RestController
+public class AdminRestController {
+    private final AdminService adminService;
+
+    @Autowired
+    public AdminRestController(AdminService adminService) {
+        this.adminService = adminService;
+    }
+
+    @PostMapping("/login")
+    public ResponseEntity<Admin> getLogin(@RequestBody IdAndPassword idAndPassword) {
+        Admin loginAdmin = adminService.login(idAndPassword);
+        if(loginAdmin != null) {
+            return ResponseEntity.ok(loginAdmin);
+        } else {
+            return ResponseEntity.status(HttpStatus.UNAUTHORIZED).build();
+        }
+    }
+
+}

--- a/src/main/java/org/dry/controller/AdminRestController.java
+++ b/src/main/java/org/dry/controller/AdminRestController.java
@@ -1,18 +1,15 @@
 package org.dry.controller;
 
+import jakarta.servlet.http.HttpSession;
 import org.dry.entity.Admin;
 import org.dry.service.AdminService;
 import org.dry.vo.IdAndPassword;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.data.rest.core.annotation.RepositoryRestResource;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
-@RequestMapping("/admin")
+@RequestMapping("/api/admin")
 @RestController
 public class AdminRestController {
     private final AdminService adminService;
@@ -22,13 +19,15 @@ public class AdminRestController {
         this.adminService = adminService;
     }
 
-    @PostMapping("/login")
-    public ResponseEntity<Admin> getLogin(@RequestBody IdAndPassword idAndPassword) {
-        Admin loginAdmin = adminService.login(idAndPassword);
-        if(loginAdmin != null) {
-            return ResponseEntity.ok(loginAdmin);
+    @PostMapping("/login") // Ajax에서 작성한 IdAandPassword (Json으로 넘어올 예정), session 등록을 위한 객체
+    public ResponseEntity<Admin> login(@RequestBody IdAndPassword idAndPassword, HttpSession session) {
+        Admin loginAdmin = adminService.login(idAndPassword); // 넘어온 걸로 객체 db에서 찾아서
+        if(loginAdmin != null) { // 객체가 잘 찾아졌으면
+            session.setAttribute("loginAdmin", loginAdmin); // session에 로그인 정보 객체 담고
+            return ResponseEntity.ok(loginAdmin); // ok 응답에 로그인 정보 객체 같이 실어서 보냄
         } else {
-            return ResponseEntity.status(HttpStatus.UNAUTHORIZED).build();
+            return ResponseEntity.status(HttpStatus.UNAUTHORIZED).build(); // 실패했으면 실패 상태코드를 보냄
+            // .build() : json객체로 만들기
         }
     }
 

--- a/src/main/java/org/dry/controller/AdminViewController.java
+++ b/src/main/java/org/dry/controller/AdminViewController.java
@@ -8,13 +8,22 @@ import org.springframework.web.bind.annotation.RequestMapping;
 @RequestMapping("/admin")
 @Controller
 public class AdminViewController {
-
-    @GetMapping("/login")
-    public String getLogin() {
+    @GetMapping("/login") // 로그인 view 화면
+    public String login() {
         return "admin/login";
     }
 
-    @GetMapping("/sign-up")
+    @GetMapping("/loginSuccess") // 로그인에 성공했을 때의 url
+    public String loginSuccess() {
+        return "admin/index";
+    }
+
+    @GetMapping("/loginFail") // 로그인에 실패했을 때의 url
+    public String loginFail() {
+        return "error/admin-login-failed";
+    }
+
+    @GetMapping("/sign-up") // 회원 가입 view 화면
     public String getSignUp() {
         return "admin/sign-up";
     }

--- a/src/main/java/org/dry/controller/AdminViewController.java
+++ b/src/main/java/org/dry/controller/AdminViewController.java
@@ -1,0 +1,22 @@
+package org.dry.controller;
+
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+
+
+@RequestMapping("/admin")
+@Controller
+public class AdminViewController {
+
+    @GetMapping("/login")
+    public String getLogin() {
+        return "admin/login";
+    }
+
+    @GetMapping("/sign-up")
+    public String getSignUp() {
+        return "admin/sign-up";
+    }
+
+}

--- a/src/main/java/org/dry/repository/AdminRepository.java
+++ b/src/main/java/org/dry/repository/AdminRepository.java
@@ -2,7 +2,9 @@ package org.dry.repository;
 
 import org.dry.entity.Admin;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.rest.core.annotation.RepositoryRestResource;
 
+@RepositoryRestResource
 public interface AdminRepository extends JpaRepository<Admin, Integer> {
 
 }

--- a/src/main/java/org/dry/vo/IdAndPassword.java
+++ b/src/main/java/org/dry/vo/IdAndPassword.java
@@ -1,10 +1,10 @@
 package org.dry.vo;
 
-import lombok.AllArgsConstructor;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
-import lombok.Setter;
+import lombok.*;
 
+import java.util.Objects;
+
+@ToString
 @NoArgsConstructor
 @AllArgsConstructor
 @Setter
@@ -12,4 +12,16 @@ import lombok.Setter;
 public class IdAndPassword {
     private String id;
     private String password;
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (!(o instanceof IdAndPassword that)) return false;
+        return Objects.equals(id, that.id) && Objects.equals(password, that.password);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(id, password);
+    }
 }

--- a/src/main/resources/templates/admin/index.html
+++ b/src/main/resources/templates/admin/index.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html lang="ko" xmlns:th="http://www.thymeleaf.org">
+<head>
+    <meta charset="UTF-8">
+    <title>로그인 성공 테스트 페이지</title>
+</head>
+<body>
+    <p>환영합니다, <span th:text="${session.loginAdmin.nickname}"/>님</p>
+
+</body>
+</html>

--- a/src/main/resources/templates/admin/login.html
+++ b/src/main/resources/templates/admin/login.html
@@ -1,0 +1,54 @@
+<!DOCTYPE html>
+<html lang="ko">
+<head>
+    <meta charset="UTF-8">
+    <title>Admin Login</title>
+    <script src="../../static/js/adminLogin.js"></script>
+</head>
+<body>
+    <header>
+
+    </header>
+
+    <main>
+        <div class="formStyle">
+                <input type="text" id="id" name="id" placeholder="아이디를 입력하세요." />
+                <input type="password" id="password" name="password" placeholder="비밀번호를 입력하세요." />
+                <input type="button" class="button" value="로그인" onclick="performLogin()" />
+            <button class="sign-up-button">회원가입</button>
+        </div>
+    </main>
+
+    <footer>
+
+    </footer>
+    <script>
+        function performLogin() {
+            const idAndPassword = { // RequestBody에 들어갈 Json의 이름, RestController 에서 받아쓸 수 있다.
+                id: document.getElementById("id").value,
+                password: document.getElementById("password").value
+            };
+
+            fetch("/api/admin/login", { // client > Server로 요청 보내기
+                method: "POST", // POST 방식으로
+                headers: {
+                    "Content-Type": "application/json" // Json 타입으로 컨텐트를 보낼겁니다
+                },
+                body: JSON.stringify(idAndPassword) // data객체인 idAndPassword를 Json 형식으로 body에 첨부
+            })
+            .then(response => { // 요청을 보냈을때 응답이
+                if (response.ok) { // response.ok : 통신 성공 여부 boolean 값
+                    return response.json(); // 성공했을 시 응답에서 온 json 객체 리턴
+                } else { // 응답에 실패했을 시
+                    throw Error("Login Error"); // 에러 발생
+                }
+            })
+            .then(data => { // 위에서 요청이 잘 왔을 경우에는
+                window.location.href="/admin/loginSuccess"; // view단으로 GET 요청을 보내 서버 랜더링
+            }).catch(error => {
+                window.location.href="/admin/loginFail";
+            });
+        }
+    </script>
+</body>
+</html>

--- a/src/main/resources/templates/error/admin-login-failed.html
+++ b/src/main/resources/templates/error/admin-login-failed.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>로그인 실패 테스트 페이지</title>
+</head>
+<body>
+    로그인에 실패하셨습니다.
+</body>
+</html>

--- a/src/test/java/org/dry/controller/AdminRestControllerTest.java
+++ b/src/test/java/org/dry/controller/AdminRestControllerTest.java
@@ -1,0 +1,50 @@
+package org.dry.controller;
+
+import jakarta.persistence.Id;
+import org.dry.entity.Admin;
+import org.dry.service.AdminService;
+import org.dry.vo.IdAndPassword;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@DisplayName("Rest Controller - Admin")
+@WebMvcTest(AdminRestController.class)
+class AdminRestControllerTest {
+    private final MockMvc mvc;
+    private final AdminRestController adminRestController;
+    @MockBean
+    private AdminService adminService;
+
+    public AdminRestControllerTest(@Autowired MockMvc mvc, @Autowired AdminRestController adminRestController) {
+        this.mvc = mvc;
+        this.adminRestController = adminRestController;
+    }
+
+
+    @DisplayName("[rest] [post] Login 요청시 객체 반환?")
+    @Test
+    void givenAdminObject_whenPostRequest_thenResponseAdminObject() throws Exception {
+        // given
+        // adminService.login이 실행된다면 결과값으로 저걸 줘라
+        when(adminService.login(any(IdAndPassword.class))).thenReturn(Admin.of("abc", "1234", "abcc", "a@b.c"));
+        // when & then
+        mvc.perform(post("/admin/login")
+                .contentType(MediaType.APPLICATION_JSON) // JSON 형식으로 보낼거고
+                .content("{ \"id\": \"abc\", \"password\": \"1234\" }")) // 보내는 JSON 객체는 이거임
+                .andExpect(status().isOk()) // 응답코드가 OK(200)이냐?
+                .andExpect(jsonPath("$.id").value("abc")) // 받은 json의 id 값이 abc인가?
+                .andExpect(jsonPath("$.password").value("1234")); // 받은 json의 password 값이 "1234" 인가?
+    }
+}

--- a/src/test/java/org/dry/controller/AdminViewControllerTest.java
+++ b/src/test/java/org/dry/controller/AdminViewControllerTest.java
@@ -1,0 +1,34 @@
+package org.dry.controller;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@DisplayName("View Controller - Admin")
+@WebMvcTest(AdminViewController.class)
+class AdminViewControllerTest {
+    private final MockMvc mvc;
+
+
+    public AdminViewControllerTest(@Autowired MockMvc mvc) {
+        this.mvc = mvc;
+    }
+
+    @DisplayName("[view] [GET] 로그인 화면 - 정상 호출?")
+    @Test
+    void givenNothing_whenRequestLoginView_thenReturnsLoginView() throws Exception {
+        // given
+
+        // when & then
+        mvc.perform(get("/admin/login"))
+                .andExpect(status().isOk())
+                .andExpect(content().contentTypeCompatibleWith(MediaType.TEXT_HTML))
+                .andExpect(view().name("admin/login"));
+    }
+}


### PR DESCRIPTION
RestController와 Controller의 책임을 분리해 간단한 Login 구현 기능

**RestController**
- view와 data를 주고 받으며 기능적인 로직을 구현함.

**Controller**
- endpoint와 view를 바인딩 해주는 역할을 함.

**구현 방식**
1. ajax 통신을 이용해 view에서 RestController로 사용자의 입력 정보를 JSON타입으로 보냄
2. 보낸 JSON객체를 이용해 RestController에서 값에 대한 처리를 함 ( DB에서 값 가져오기, session에 로그인 정보 추가 등)
3. 문제가 없다면 RestController에서 ok(200) 코드를, 문제가 있다면 기타 에러 코드를 다시 view에 전달
4. view는 전달받은 response를 보고 응답에 맞는 행동을 함. ] then( ).catch( )구문 ]
5. [ then( ).catch( ) ]에서 GET요청을 Controller에서 보내 처리 결과에 맞게끔 다시 페이지를 랜더링함

**이슈 내용**
1. WebMvcTest 할 때 Service( ) 메서드가 동작하지 않음
- @MockBean 메서드를 활용해 `서비스 모의 객체 ` 를 만든 뒤 `when( ).thenReturn( )` 을 이용해 서비스의 기능을 조작함
- 신뢰성의 문제가 있다고 볼 수 있지만, 이미 Service는 따로 Test를 완료했기 때문에 상관없다고 생각함

2. RESTful한 endpoint 이름 짓기
- 공부 필요

This closes #21 